### PR TITLE
Add generator extension to add frozen_string_literal comment

### DIFF
--- a/config/initializers/generators/frozen_string_literal.rb
+++ b/config/initializers/generators/frozen_string_literal.rb
@@ -1,42 +1,44 @@
 # frozen_string_literal: true
 
-require "rails/generators/migration"
-
 # https://gist.github.com/ta1kt0me/6a7058d16621785d4f7038bde6cd3b98
 
-module AddFrozenStringLiteralComment
-  def add_frozen_string_literal_comment(dist)
-    return unless File.exist?(dist) && File.extname(dist) == ".rb"
+if defined?(::Rails::Generators)
+  require "rails/generators/migration"
 
-    File.open(dist, "r") do |f|
-      body = f.read
+  module AddFrozenStringLiteralComment
+    def add_frozen_string_literal_comment(dist)
+      return unless File.exist?(dist) && File.extname(dist) == ".rb"
 
-      File.open(dist, "w") do |new_f|
-        new_f.write("# frozen_string_literal: true\n\n" + body)
+      File.open(dist, "r") do |f|
+        body = f.read
+
+        File.open(dist, "w") do |new_f|
+          new_f.write("# frozen_string_literal: true\n\n" + body)
+        end
       end
     end
   end
-end
 
-module GeneratorPrepend
-  include AddFrozenStringLiteralComment
+  module GeneratorPrepend
+    include AddFrozenStringLiteralComment
 
-  def invoke!
-    res = super
-    add_frozen_string_literal_comment(existing_migration)
-    res
+    def invoke!
+      res = super
+      add_frozen_string_literal_comment(existing_migration)
+      res
+    end
   end
-end
 
-module TemplatePrepend
-  include AddFrozenStringLiteralComment
+  module TemplatePrepend
+    include AddFrozenStringLiteralComment
 
-  def template(source, *args, &block)
-    res = super
-    add_frozen_string_literal_comment(args.first)
-    res
+    def template(source, *args, &block)
+      res = super
+      add_frozen_string_literal_comment(args.first)
+      res
+    end
   end
-end
 
-Rails::Generators::Actions::CreateMigration.send :prepend, GeneratorPrepend
-Rails::Generators::NamedBase.send :prepend, TemplatePrepend
+  Rails::Generators::Actions::CreateMigration.send :prepend, GeneratorPrepend
+  Rails::Generators::NamedBase.send :prepend, TemplatePrepend
+end

--- a/config/initializers/generators/frozen_string_literal.rb
+++ b/config/initializers/generators/frozen_string_literal.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails/generators/migration"
+
+# https://gist.github.com/ta1kt0me/6a7058d16621785d4f7038bde6cd3b98
+
+module AddFrozenStringLiteralComment
+  def add_frozen_string_literal_comment(dist)
+    return unless File.exist?(dist) && File.extname(dist) == ".rb"
+
+    File.open(dist, "r") do |f|
+      body = f.read
+
+      File.open(dist, "w") do |new_f|
+        new_f.write("# frozen_string_literal: true\n\n" + body)
+      end
+    end
+  end
+end
+
+module GeneratorPrepend
+  include AddFrozenStringLiteralComment
+
+  def invoke!
+    res = super
+    add_frozen_string_literal_comment(existing_migration)
+    res
+  end
+end
+
+module TemplatePrepend
+  include AddFrozenStringLiteralComment
+
+  def template(source, *args, &block)
+    res = super
+    add_frozen_string_literal_comment(args.first)
+    res
+  end
+end
+
+Rails::Generators::Actions::CreateMigration.send :prepend, GeneratorPrepend
+Rails::Generators::NamedBase.send :prepend, TemplatePrepend


### PR DESCRIPTION
## Why?
- Our rubocop configs require the `frozen_string_literal: true` comment at the top of files. The generators should generate files with it.

## What Changed?
- Add a generator config that will add those comments at the top of generated files