### PR TITLE
Updating Travis Config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 sudo: required
-dist: trusty
 language: ruby
 rvm:
   - 2.4.2
+services:
+  - xvfb
+  - postgresql
 addons:
   chrome: stable
 cache: 
@@ -16,7 +18,6 @@ before_install:
 before_script:
   - export PATH=$PATH:/usr/lib/chromium-browser/
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
   - sleep 3
   - cp .env.example .env
   - psql -c 'create database racxob_test;' -U postgres

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,7 +197,7 @@ GEM
     msgpack (1.2.10)
     netrc (0.11.0)
     nio4r (2.3.1)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     parallel (1.17.0)
     parser (2.6.3.0)


### PR DESCRIPTION
Chrome is no longer publishing packages for the `trusty` build target, so we needed to migrate to the default build environment that travis us running.